### PR TITLE
Objectize ButtonBox

### DIFF
--- a/gtk-sys/src/lib.rs
+++ b/gtk-sys/src/lib.rs
@@ -1853,6 +1853,7 @@ extern "C" {
     //=========================================================================
     // GtkButtonBox                                                          OK
     //=========================================================================
+    pub fn gtk_button_box_get_type             () -> GType;
     pub fn gtk_button_box_new                  (orientation: enums::Orientation) -> *mut GtkWidget;
     pub fn gtk_button_box_get_layout           (widget: *mut GtkButtonBox) -> enums::ButtonBoxStyle;
     pub fn gtk_button_box_get_child_secondary  (widget: *mut GtkButtonBox, child : *mut GtkWidget) -> gboolean;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,7 @@ pub use widgets::arrow::Arrow;
 pub use widgets::bin::Bin;
 pub use widgets::box_::Box;
 pub use widgets::button::Button;
+pub use widgets::button_box::ButtonBox;
 pub use widgets::container::Container;
 pub use widgets::calendar::Calendar;
 pub use widgets::drawing_area::DrawingArea;

--- a/src/widgets/button_box.rs
+++ b/src/widgets/button_box.rs
@@ -4,52 +4,87 @@
 
 //! A container for arranging buttons
 
-use {Orientation, ButtonBoxStyle};
-use cast::GTK_BUTTONBOX;
+use glib::translate::*;
+use glib::types;
 use ffi;
-use glib::{to_bool, to_gboolean};
+
+use object::{Object, Upcast, Downcast};
+use super::widget::Widget;
+use {
+    Orientation,
+    ButtonBoxStyle,
+};
 
 /// ButtonBox — A container for arranging buttons
-struct_Widget!(ButtonBox);
+pub type ButtonBox = Object<ffi::GtkButtonBox>;
 
-impl ButtonBox {
-    pub fn new(orientation: Orientation) -> Option<ButtonBox> {
-        let tmp_pointer = unsafe { ffi::gtk_button_box_new(orientation) };
-        check_pointer!(tmp_pointer, ButtonBox)
-    }
+unsafe impl Upcast<Widget> for ButtonBox { }
+unsafe impl Upcast<super::container::Container> for ButtonBox { }
+unsafe impl Upcast<::builder::Buildable> for ButtonBox { }
+unsafe impl Upcast<super::orientable::Orientable> for ButtonBox { }
 
-    pub fn get_layout(&self) -> ButtonBoxStyle {
-        unsafe {
-            ffi::gtk_button_box_get_layout(GTK_BUTTONBOX(self.pointer))
-        }
-    }
-
-    pub fn get_child_secondary<T: ::WidgetTrait + ::ButtonTrait>(&self, child: &T) -> bool {
-        unsafe { to_bool(ffi::gtk_button_box_get_child_secondary(GTK_BUTTONBOX(self.pointer), child.unwrap_widget())) }
-    }
-
-    pub fn get_child_non_homogeneous<T: ::WidgetTrait + ::ButtonTrait>(&self, child: &T) -> bool {
-        unsafe { to_bool(ffi::gtk_button_box_get_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.unwrap_widget())) }
-    }
-
-    pub fn set_layout(&self, layout_style: ButtonBoxStyle) -> () {
-        unsafe {
-            ffi::gtk_button_box_set_layout(GTK_BUTTONBOX(self.pointer), layout_style)
-        }
-    }
-
-    pub fn set_child_secondary<T: ::WidgetTrait + ::ButtonTrait>(&self, child: &T, is_secondary: bool) -> () {
-        unsafe { ffi::gtk_button_box_set_child_secondary(GTK_BUTTONBOX(self.pointer), child.unwrap_widget(), to_gboolean(is_secondary)); }
-    }
-
-    pub fn set_child_non_homogeneous<T: ::WidgetTrait + ::ButtonTrait>(&self, child: &T, non_homogeneous: bool) -> () {
-        unsafe { ffi::gtk_button_box_set_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.unwrap_widget(), to_gboolean(non_homogeneous)); }
+impl types::StaticType for ButtonBox {
+    #[inline]
+    fn static_type() -> types::Type {
+        unsafe { from_glib(ffi::gtk_button_box_get_type()) }
     }
 }
 
-impl_drop!(ButtonBox);
-impl_TraitWidget!(ButtonBox);
-
-impl ::ContainerTrait for ButtonBox {}
-impl ::BoxTrait for ButtonBox {}
-impl ::OrientableTrait for ButtonBox {}
+impl ButtonBox {
+    /// Creates a new ButtonBox.
+    pub fn new(orientation: Orientation) -> ButtonBox {
+        unsafe {
+            Widget::from_glib_none(ffi::gtk_button_box_new(orientation)).downcast_unchecked()
+        }
+    }
+    /// Retrieves the method being used to arrange the buttons in a button box.
+    pub fn get_layout(&self) -> ButtonBoxStyle {
+        unsafe { ffi::gtk_button_box_get_layout(self.to_glib_none().0) }
+    }
+    /// Returns whether `child` should appear in a secondary group of children.
+    pub fn get_child_secondary<T: Upcast<Widget>>(&self, child: &T) -> bool {
+        unsafe {
+            from_glib(
+                ffi::gtk_button_box_get_child_secondary(self.to_glib_none().0,
+                    child.upcast().to_glib_none().0))
+        }
+    }
+    /// Returns whether the `child` is exempted from homogenous sizing.
+    pub fn get_child_non_homogeneous<T: Upcast<Widget>>(&self, child: &T) -> bool {
+        unsafe {
+            from_glib(
+                ffi::gtk_button_box_get_child_non_homogeneous(self.to_glib_none().0,
+                    child.upcast().to_glib_none().0))
+        }
+    }
+    /// Changes the way buttons are arranged in their container.
+    pub fn set_layout(&self, layout_style: ButtonBoxStyle) {
+        unsafe {
+            ffi::gtk_button_box_set_layout(self.to_glib_none().0, layout_style)
+        }
+    }
+    /// Sets whether child should appear in a secondary group of children.
+    /// A typical use of a secondary child is the help button in a dialog.
+    /// This group appears after the other children
+    /// if the style is `ButtonBoxStyle::Start`, `ButtonBoxStyle::Spread` or `ButtonBoxStyle::Edge`,
+    /// and before the other children if the style is `ButtonBoxStyle::End`.
+    /// For horizontal button boxes, the definition of before/after depends
+    /// on direction of the widget (see gtk_widget_set_direction()).
+    /// If the style is `ButtonBoxStyle::Start` or `ButtonBoxStyle::End`,
+    /// then the secondary children are aligned at the other end of the button box
+    /// from the main children.
+    /// For the other styles, they appear immediately next to the main children.
+    pub fn set_child_secondary<T: Upcast<Widget>>(&self, child: &T, is_secondary: bool) {
+        unsafe {
+            ffi::gtk_button_box_set_child_secondary(self.to_glib_none().0,
+                child.upcast().to_glib_none().0, is_secondary.to_glib());
+        }
+    }
+    /// Sets whether the child is exempted from homogeous sizing.
+    pub fn set_child_non_homogeneous<T: Upcast<Widget>>(&self, child: &T, non_homogeneous: bool) {
+        unsafe {
+            ffi::gtk_button_box_set_child_non_homogeneous(self.to_glib_none().0,
+                child.upcast().to_glib_none().0, non_homogeneous.to_glib());
+        }
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -10,6 +10,7 @@ pub mod arrow;
 pub mod bin;
 pub mod box_;
 pub mod button;
+pub mod button_box;
 pub mod calendar;
 pub mod combo_box;
 pub mod container;


### PR DESCRIPTION
Added constraint + ButtonExt for child functions, it works.
When attempt check info on label this error appear:
```
error: the trait `glib::object::Upcast<gtk::object::Object<gtk_sys::GtkButton>>` is not implemented for the type `gtk::object::Object<gtk_sys::GtkLabel>` [E0277]
```
Can't find way add same constraint on `add`.
Now not sure about the need to constraint at all. May be it normal add Labels to ButtonBox