### PR TITLE
Enable socket only for X11

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,7 @@ pub use widgets::radio_button::RadioButton;
 pub use widgets::scrollable::Scrollable;
 pub use widgets::separator::Separator;
 pub use widgets::spinner::Spinner;
+#[cfg(target_os = "linux")]
 pub use widgets::socket::Socket;
 #[cfg(feature = "gtk_3_10")]
 pub use widgets::stack::{

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -40,6 +40,7 @@ pub mod progress_bar;
 pub mod radio_button;
 pub mod scrollable;
 pub mod separator;
+#[cfg(target_os = "linux")]
 pub mod socket;
 pub mod spinner;
 #[cfg(feature = "gtk_3_10")]


### PR DESCRIPTION
Current version just not linking under Windows7.
Not sure if `linux` equivalent of X11 (https://developer.gnome.org/gtk3/stable/GtkSocket.html)
